### PR TITLE
fix ordinalize functionality

### DIFF
--- a/vendor/assets/javascripts/inflection.js
+++ b/vendor/assets/javascripts/inflection.js
@@ -626,8 +626,7 @@ if (!String.prototype.ordinalize)
         var str_arr = str.split(' ');
         for (var x = 0; x < str_arr.length; x++)
         {
-            var i = parseInt(str_arr[x]);
-            if (i === NaN)
+            if (!isNaN(Number(str_arr[x])))
             {
                 var ltd = str_arr[x].substring(str_arr[x].length - 2);
                 var ld = str_arr[x].substring(str_arr[x].length - 1);


### PR DESCRIPTION
Just emailed Ryan Schuft about this bug:

This:

``` js
var i = parseInt(str_arr[x]);
if (i === NaN)
...
```

should be changed to this:

``` js
var i = Number(str_arr[x]);
if (!isNaN(i))
...
```

because...
1. parseInt("4things") would return 4 whereas Number("4things") would return NaN which is what we want.
2. We are actually looking for numbers (not NaNs) for the code block below.
3. You can't compare NaN to NaN using === (have to use isNaN() function).
